### PR TITLE
Clone with remote name "upstream"

### DIFF
--- a/lila-docker
+++ b/lila-docker
@@ -17,7 +17,7 @@ run_setup() {
     repos=($(echo $REPOS | tr ',' ' '))
     echo "Cloning repos ${repos[@]}..."
     for repo in "${repos[@]}"; do
-        [ ! -d repos/$repo/.git ] && git clone --depth 1 --origin lichess-org https://github.com/lichess-org/$repo repos/$repo
+        [ ! -d repos/$repo/.git ] && git clone --depth 1 --origin upstream https://github.com/lichess-org/$repo repos/$repo
     done
 
     git -C repos/lila submodule update --init


### PR DESCRIPTION
The VS Code Github PR extension will automatically show PRs only from remotes names "upstream" or "origin". Use upstream and reserve origin for the user's fork.