### PR TITLE
Set null pidfile for lila-fishnet

### DIFF
--- a/docker/lila-fishnet.Dockerfile
+++ b/docker/lila-fishnet.Dockerfile
@@ -3,4 +3,7 @@ FROM sbtscala/scala-sbt:eclipse-temurin-focal-17.0.8.1_1_1.9.7_3.3.1
 WORKDIR /lila-fishnet
 
 ENTRYPOINT sbt stage && \
-    ./target/universal/stage/bin/lila-fishnet -Dhttp.port=9665 -Dredis.uri="redis://redis"
+    ./target/universal/stage/bin/lila-fishnet \
+        -Dhttp.port=9665 \
+        -Dpidfile.path=/dev/null \
+        -Dredis.uri="redis://redis"


### PR DESCRIPTION
On some restarts, it would error with:

"This application is already running (or delete /lila-fishnet/target/universal/stage/RUNNING_PID file)."