### PR TITLE
Setup Gitpod prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,6 @@
 tasks:
+  - init: |
+      ./lila-docker build
   - command: |
       ./lila-docker start
       ./lila-docker gitpod-welcome


### PR DESCRIPTION
Enable Gitpod prebuilds for faster workspace startup and prevent issues if the Docker Hub Registry is down.