### PR TITLE
Add lila-docker restart option

### DIFF
--- a/lila-docker
+++ b/lila-docker
@@ -133,7 +133,7 @@ run_gitpod_welcome() {
 }
 
 show_help() {
-    echo "Usage: $0 [start|stop|down|build|format]"
+    echo "Usage: $0 [start|stop|restart|down|build|format]"
 }
 
 case $1 in

--- a/lila-docker
+++ b/lila-docker
@@ -147,6 +147,9 @@ case $1 in
     stop)
         run_stop
         ;;
+    restart)
+        run_stop && run_start
+        ;;
     down)
         run_down
         ;;


### PR DESCRIPTION
This PR adds restart (`./lila-docker restart`) option, which  will stop the containers and then start them.
This would save time when compared with typing both start and stop commands sequentially.