### PR TITLE
Nginx conf to support lifat versioned urls

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -6,8 +6,8 @@ server {
     client_max_body_size 4M;
     root /lila/public;
 
-    location /assets/lifat {
-        alias /lifat;
+    location ~ ^/assets(\/_\w+)?/lifat/(?<file>.*)$ {
+        alias /lifat/$file;
     }
 
     location / {


### PR DESCRIPTION
Flair picker requests a versioned URL

Support both of these URL structures:

```
/assets/lifat/flair/list.txt
/assets/_EjWdDH/lifat/flair/list.txt
```