### PR TITLE
Add VSCode workspace for easier repo navigation

### DIFF
--- a/lichess.code-workspace
+++ b/lichess.code-workspace
@@ -1,0 +1,54 @@
+{
+	// All paths are relative to the repo
+	// This unifies navigation in VSCode (useful for Gitpod users)
+	"folders": [
+		{
+			"path": "." // lila-docker
+		},
+		{
+			"path": "repos/lila" 
+		},
+		{
+			"path": "repos/lila-ws"
+		},
+		{
+			"path": "repos/lila-db-seed"
+		},
+		{
+			"path": "repos/lifat"
+		},
+		{
+			"path": "repos/lila-fishnet"
+		},
+		{
+			"path": "repos/lila-engine"
+		},
+		{
+			"path": "repos/lila-search"
+		},
+		{
+			"path": "repos/lila-gif"
+		},
+		{
+			"path": "repos/api"
+		},
+		{
+			"path": "repos/chessground"
+		},
+		{
+			"path": "repos/pgn-viewer"
+		},
+		{
+			"path": "repos/scalachess"
+		},
+		{
+			"path": "repos/dartchess"
+		},
+		{
+			"path": "repos/berserk"
+		},
+		{
+			"path": "repos/bbpPairings"
+		}
+	],
+}

--- a/lichess.code-workspace
+++ b/lichess.code-workspace
@@ -1,54 +1,52 @@
 {
-	// All paths are relative to the repo
-	// This unifies navigation in VSCode (useful for Gitpod users)
-	"folders": [
-		{
-			"path": "." // lila-docker
-		},
-		{
-			"path": "repos/lila" 
-		},
-		{
-			"path": "repos/lila-ws"
-		},
-		{
-			"path": "repos/lila-db-seed"
-		},
-		{
-			"path": "repos/lifat"
-		},
-		{
-			"path": "repos/lila-fishnet"
-		},
-		{
-			"path": "repos/lila-engine"
-		},
-		{
-			"path": "repos/lila-search"
-		},
-		{
-			"path": "repos/lila-gif"
-		},
-		{
-			"path": "repos/api"
-		},
-		{
-			"path": "repos/chessground"
-		},
-		{
-			"path": "repos/pgn-viewer"
-		},
-		{
-			"path": "repos/scalachess"
-		},
-		{
-			"path": "repos/dartchess"
-		},
-		{
-			"path": "repos/berserk"
-		},
-		{
-			"path": "repos/bbpPairings"
-		}
-	],
+  "folders": [
+    {
+      "path": "."
+    },
+    {
+      "path": "repos/lila"
+    },
+    {
+      "path": "repos/lila-ws"
+    },
+    {
+      "path": "repos/lila-db-seed"
+    },
+    {
+      "path": "repos/lifat"
+    },
+    {
+      "path": "repos/lila-fishnet"
+    },
+    {
+      "path": "repos/lila-engine"
+    },
+    {
+      "path": "repos/lila-search"
+    },
+    {
+      "path": "repos/lila-gif"
+    },
+    {
+      "path": "repos/api"
+    },
+    {
+      "path": "repos/chessground"
+    },
+    {
+      "path": "repos/pgn-viewer"
+    },
+    {
+      "path": "repos/scalachess"
+    },
+    {
+      "path": "repos/dartchess"
+    },
+    {
+      "path": "repos/berserk"
+    },
+    {
+      "path": "repos/bbpPairings"
+    }
+  ]
 }


### PR DESCRIPTION
solves the need of opening a separate folder/workspace tab to work on cloned repositories (eg lila)
this can be deployed in .gitpod.yml by appending  `workspaceLocation: lila-docker/lichess.code-workspace # Relative to /workspace dir`
intentionally left this out because this change would cause existing users to land at a blank canvas because of the new workspace instead of the used lila-docker folder workspace or other repositories they opened
the quick solution is tell users to run `open /workspace/lila-docker` or the relevant repository eg `open /workspace/repos/lila` in a terminal and finish working on there