### PR TITLE
make database available outside of the container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./repos/lila:/lila
       - ./scripts:/scripts
+      - ./database:/data/db
 
   redis:
     image: redis:7.2.3-alpine3.18


### PR DESCRIPTION
this would have the benefit of keeping the database data when running `./lila-docker down` and bringing it back up due to the need of changing optional components and such