### PR TITLE
Default InfluxDB ENABLE_MONITORING to false

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - SCHEME=${SCHEME:-http}
       - LILA_DOMAIN=${LILA_DOMAIN:-localhost:8080}
       - PICFIT_DOMAIN=${PICFIT_DOMAIN:-localhost:3001}
-      - ENABLE_MONITORING=${ENABLE_MONITORING}
+      - ENABLE_MONITORING=${ENABLE_MONITORING:-false}
     volumes:
       - ./repos/lila:/lila
       - ./repos/chessground:/chessground


### PR DESCRIPTION
Default InfluxDB `ENABLE_MONITORING` to false to suppress the following message:

![image](https://github.com/lichess-org/lila-docker/assets/3620552/2adb0332-a104-4a31-9a63-662a84ad2437)
