### PR TITLE
Nginx http2 configuration

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen       80;
     listen  [::]:80;
@@ -21,20 +26,27 @@ server {
         error_page 502 /502/picfit-placeholder.png;
     }
 
-    location / {
-        try_files $uri @$http_upgrade;
-    }
+    location /websocket/ {
+        internal;
 
-    # lila-ws (websocket) traffic
-    location @websocket {
-        proxy_pass http://lila_ws:9664;
+        proxy_pass http://lila_ws:9664/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
+        proxy_set_header Connection $connection_upgrade;
     }
 
-    # lila traffic
-    location @ {
+    location / {
+        set $websocket 1;
+        if ($http_connection !~* "upgrade") {
+            set $websocket 0;
+        }
+        if ($http_upgrade !~* "websocket") {
+            set $websocket 0;
+        }
+        if ($websocket) {
+            rewrite ^ /websocket$uri last;
+        }
+
         proxy_pass http://lila:9663;
         proxy_http_version 1.1;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
Fixes

```
nginx-1  | 2023/12/14 21:54:39 [error] 22#22: *316 could not find named location "@h2c", client: 172.18.0.1, server: lichess, request: "GET /api/stream/event HTTP/1.1", host: "localhost:8080"
nginx-1  | 172.18.0.1 - - [14/Dec/2023:21:54:39 +0000] "GET /api/stream/event HTTP/1.1" 500 177 "-" "Java/21.0.1 chariot/?" "-"
```

To recreate: 

```bash
curl localhost:8080/api/stream/event -N -H "Authorization: Bearer lip_abc123" --http2
```

https://serverfault.com/a/1120503