### PR TITLE
Add berserk script to make bots online

### DIFF
--- a/scripts/berserk-connect-bots.py
+++ b/scripts/berserk-connect-bots.py
@@ -1,0 +1,12 @@
+import berserk
+import concurrent.futures
+
+def connect_bot(token):
+    session = berserk.TokenSession(token)
+    client = berserk.Client(session, base_url="http://nginx")
+    generator = client.bots.stream_incoming_events()
+    return next(generator)
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=9) as executor:
+    tokens = [f'lip_bot{index}' for index in range(9)]
+    executor.map(connect_bot, tokens)


### PR DESCRIPTION
While running this script, the bot-accounts (bot0-9) will be connected to the dev instance so they show up as online on the /player/bots page