### PR TITLE
Auto compile bbpPairings when Swiss Pairings option is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,16 +193,6 @@ docker compose run --rm -w /dartchess mobile bash -c "dart pub get && dart analy
 docker compose run --rm -w /dartchess mobile bash -c "dart pub get && dart test -x full_perft"
 ```
 
-### bbpPairings:
-
-```bash
-docker build -f docker/bbpPairings.Dockerfile . -t bbppairings
-docker run --rm -v $(pwd)/repos/bbpPairings:/mnt bbppairings make
-
-## verify
-./repos/bbpPairings/bbpPairings.exe
-```
-
 ### Developing Chessground locally
 
 By default, your local lila instance will use the version of chessground that is published to npm. If you want to make changes to that library and see them reflected in your local lila instance, you can do the following:

--- a/command/Cargo.lock
+++ b/command/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -220,7 +220,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -273,22 +273,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
 dependencies = [
  "indexmap",
  "serde",
@@ -477,9 +477,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.39"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
+checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
 dependencies = [
  "memchr",
 ]
@@ -501,5 +501,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -26,6 +26,7 @@ const BANNER: &str = r"
 struct Config {
     compose_profiles: Option<Vec<String>>,
     setup_database: Option<bool>,
+    setup_bbppairings: Option<bool>,
     enable_monitoring: Option<bool>,
     su_password: Option<String>,
     password: Option<String>,
@@ -73,6 +74,7 @@ impl Config {
         let Self {
             compose_profiles,
             setup_database,
+            setup_bbppairings,
             enable_monitoring,
             su_password,
             password,
@@ -88,9 +90,10 @@ impl Config {
             .map(|v| v.join(","))
             .unwrap_or_default();
         format!(
-            "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n",
+            "{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n{}\n",
             to_env!(compose_profiles, compose_profiles_string),
             to_env!(setup_database),
+            to_env!(setup_bbppairings),
             to_env!(enable_monitoring),
             to_env!(su_password),
             to_env!(password),
@@ -207,6 +210,13 @@ fn setup(mut config: Config) -> std::io::Result<()> {
             .collect(),
     );
     config.setup_database = Some(setup_database);
+
+    config.setup_bbppairings = Some(
+        services
+            .iter()
+            .any(|service| service.compose_profile == Some(vec!["swiss-pairings"])),
+    );
+
     config.enable_monitoring = Some(
         services
             .iter()
@@ -432,7 +442,7 @@ fn prompt_for_optional_services() -> Result<Vec<OptionalService<'static>>, Error
     )
     .item(
         OptionalService {
-            compose_profile: None,
+            compose_profile: vec!["swiss-pairings"].into(),
             repositories: vec![Repository::new("cyanfish", "bbpPairings")].into(),
         },
         "Swiss Pairings",
@@ -562,6 +572,7 @@ mod tests {
         let contents = Config {
             compose_profiles: Some(vec!["foo".to_string(), "bar".to_string()]),
             setup_database: Some(true),
+            setup_bbppairings: Some(false),
             enable_monitoring: Some(false),
             su_password: Some("foo".to_string()),
             password: Some("bar".to_string()),
@@ -581,6 +592,7 @@ mod tests {
 
         assert_eq!(vars["COMPOSE_PROFILES"], "foo,bar");
         assert_eq!(vars["SETUP_DATABASE"], "true");
+        assert_eq!(vars["SETUP_BBPPAIRINGS"], "false");
         assert_eq!(vars["ENABLE_MONITORING"], "false");
         assert_eq!(vars["SU_PASSWORD"], "foo");
         assert_eq!(vars["PASSWORD"], "bar");

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -522,7 +522,7 @@ fn mobile_setup(mut config: Config) -> std::io::Result<()> {
     outro("Pairing and connecting to phone...")
 }
 
-fn validate_string_length(input: &String, length: usize) -> Result<(), String> {
+fn validate_string_length(input: &str, length: usize) -> Result<(), String> {
     match input.len() {
         len if len == length => Ok(()),
         _ => Err(format!("Value should be {length} digits in length")),

--- a/lila-docker
+++ b/lila-docker
@@ -8,6 +8,7 @@ run_setup() {
     docker compose up -d
     docker compose run --rm ui /lila/ui/build --debug
 
+    setup_bbppairings
     setup_database
     rust_cmd welcome
 }
@@ -66,6 +67,18 @@ setup_database() {
     docker compose run --rm mongodb mongo --quiet --host mongodb lichess /lila/bin/mongodb/indexes.js
     docker compose run --rm mongodb mongo --quiet --host mongodb lichess /lila/bin/mongodb/create-trophy-kinds.js
     docker compose run --rm python python /scripts/users.py
+}
+
+setup_bbppairings() {
+    if [ "$SETUP_BBPPAIRINGS" != "true" ]; then
+        return
+    fi
+
+    docker build -f docker/bbpPairings.Dockerfile . -t bbppairings
+    docker run --rm -v ./repos/bbpPairings:/mnt bbppairings make
+
+    ## verify it compiled
+    ./repos/bbpPairings/bbpPairings.exe
 }
 
 reset_database() {


### PR DESCRIPTION
Before, if you select "Swiss Pairings" in the setup prompt, it would only clone the repo. Then you had to manually run the commands to compile the binary.

Now it will do it automatically as part of the setup.