### PR TITLE
Reduce image size with multi-stage build

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -33,7 +33,7 @@ RUN ./lila stage
 ##################################################################################
 FROM mongo:7-jammy
 
-RUN apt update && apt install -y redis python3-pip && apt clean
+RUN apt update && apt install -y curl redis python3-pip && apt clean
 RUN pip3 install berserk pytest
 
 COPY --from=dbbuilder /seeded /seeded

--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -1,33 +1,17 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-jammy-21.0.2_13_1.9.9_3.4.0
+##################################################################################
+FROM mongo:7-jammy as dbbuilder
 
-# Install mongodb
-# https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/
-RUN apt-get update \
-    && apt-get install gnupg curl -y \
-    && curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | \
-        gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg \
-        --dearmor \
-    && echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
-    && apt-get update \
-    && apt-get install -y mongodb-org \
-    && apt-get clean \
-    && mkdir -p /data/db
-
-# Install redis
-# https://redis.io/docs/install/install-redis/install-redis-on-linux/
-RUN apt install lsb-release curl gpg -y \
-    && curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list \
-    && apt-get update \
-    && apt-get install redis -y \
-    && apt-get clean
+RUN apt update && apt install -y git python3-pip curl
+RUN pip3 install pymongo requests
+RUN curl -L https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.2%2B13/OpenJDK21U-jdk_x64_linux_hotspot_21.0.2_13.tar.gz | tar xzf - && mv jdk-21* /jdk-21
+ENV PATH=/jdk-21/bin:$PATH
 
 RUN git clone --depth 1 https://github.com/lichess-org/lila-db-seed /lila-db-seed
 WORKDIR /lila-db-seed
-RUN apt install python3-pip -y \
-    && pip3 install pymongo requests
-RUN mongod --fork --logpath /var/log/mongod.log \
-    && ./spamdb/spamdb.py \
+
+RUN mkdir /seeded
+RUN mongod --fork --logpath /var/log/mongodb/mongod.log --dbpath /seeded \
+ && ./spamdb/spamdb.py \
         --drop-db \
         --password=password \
         --su-password=password \
@@ -35,15 +19,34 @@ RUN mongod --fork --logpath /var/log/mongod.log \
         --coaches \
         --tokens
 
-## Pre-install dependencies for Berserk client
-RUN pip3 install berserk pytest
+##################################################################################
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-21.0.2_13_1.9.9_3.4.0 as lilabuilder
 
-RUN git clone --depth 1 https://github.com/lichess-org/lila.git /lila
+RUN apt update && apt install -y git
+
+RUN mkdir /lila
 WORKDIR /lila
-
-COPY conf/ci.conf /lila/conf/application.conf
+RUN git clone --depth 1 https://github.com/lichess-org/lila.git .
+COPY conf/ci.conf ./conf/application.conf
 RUN ./lila stage
 
-CMD mongod --fork --logpath /var/log/mongod.log \
+##################################################################################
+FROM mongo:7-jammy
+
+RUN apt update && apt install -y redis python3-pip && apt clean
+RUN pip3 install berserk pytest
+
+COPY --from=dbbuilder /seeded /seeded
+COPY --from=dbbuilder /jdk-21 /jdk-21
+COPY --from=lilabuilder /lila/target /lila/target
+COPY --from=lilabuilder /lila/public /lila/public
+COPY --from=lilabuilder /lila/conf   /lila/conf
+
+ENV JAVA_HOME=/jdk-21
+ENV PATH=/jdk-21/bin:$PATH
+ENV LANG=C.utf8
+
+WORKDIR /lila
+CMD mongod --fork --logpath /var/log/mongodb/mongod.log --dbpath /seeded \
     && redis-server --daemonize yes \
     && JAVA_OPTS="-Xms4g -Xmx4g" ./target/universal/stage/bin/lila -Dconfig.file="/lila/conf/application.conf" -Dlogger.file="/lila/conf/logger.dev.xml"

--- a/docs/ci-testing.md
+++ b/docs/ci-testing.md
@@ -1,0 +1,9 @@
+## Testing the CI image build locally
+
+```bash
+docker build -t lila-ci -f docker/ci.Dockerfile .
+
+docker run -it --rm -p 9663:9663 lila-ci
+
+curl localhost:9663/api/user/lichess
+```

--- a/docs/ci-testing.md
+++ b/docs/ci-testing.md
@@ -2,8 +2,9 @@
 
 ```bash
 docker build -t lila-ci -f docker/ci.Dockerfile .
-
 docker run -it --rm -p 9663:9663 lila-ci
+```
 
+```bash
 curl localhost:9663/api/user/lichess
 ```


### PR DESCRIPTION
Here's an example "refactoring" of the `ci.Dockerfile`,
which reduces the size from 3 GB to 2 GB.

At least the integration tests in chariot are still passing,
but that should probably not be "the one source of truth" if this refactoring is sound or not :grinning: 

I think the main things which is gotten rid of with this updated image are "leftovers" from sbt and git checkouts. 

I'm not confident in that I know which files from the lila git checkout that are needed in actual runtime - but the current copying of
- /lila/target
- /lila/public
- /lila/conf

seems to work so far...
