### PR TITLE
Add .pnpm-store volume to docker-compose.yml to get benefits of pnpm

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       - 8090:8080
     volumes:
       - ./repos/chessground:/app
+      - ./.pnpm-store:/.pnpm-store
     profiles:
       - chessground
 
@@ -111,6 +112,7 @@ services:
       - 8091:8080
     volumes:
       - ./repos/pgn-viewer:/app
+      - ./.pnpm-store:/.pnpm-store
     profiles:
       - pgn-viewer
 
@@ -191,6 +193,7 @@ services:
       - ./repos/lila:/lila
       - ./repos/chessground:/chessground
       - ./repos/pgn-viewer:/pgn-viewer
+      - ./.pnpm-store:/.pnpm-store
     profiles:
       - utils
 


### PR DESCRIPTION
Addind pnpm-store to volumes doesn't download the dependencies again and again on running `./lila-docker ui` and other command which include pnpm install.
Before:
![image](https://github.com/lichess-org/lila-docker/assets/95964955/f1578b41-3975-41c8-94cb-dc5fb5ffadb4)
Downloaded packages every time on pnpm install
As far as I understand this is because `docker compose run --rm ui /lila/ui/build --update --clean-build --debug $@` makes a new container every time it is run. 
After:
![image](https://github.com/lichess-org/lila-docker/assets/95964955/f8cfa206-1c25-41f2-ab87-10cf5584a94f)
Just takes the package from pnpm-store directory and doesn't download them again.
