### PR TITLE
Add services after setup has already been completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ To add a new optional service after the initial setup has already been done:
 ```
 
 Select the service you want to add from the list of options.
-NOTE: This will not affect the existing services, only the new ones selected will be added.
+
+NOTE: This will not affect the existing services, only the new ones among the selected services will be added.
 
 ## URLs
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ To remove the containers:
 ./lila-docker down
 ```
 
+### Adding a new service
+
+To add a new optional service after the initial setup has already been done:
+
+```bash
+./lila-docker add-services
+```
+
+Select the service you want to add from the list of options.
+NOTE: This will not affect the existing services, only the new ones selected will be added.
+
 ## URLs
 
 Always available:

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -236,39 +236,37 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
     }
     let services = prompt_for_optional_services()?;
 
-    let setup_database: bool;
-    if first_setup {
-        setup_database =
-            confirm("Do you want to seed the database with test users, games, etc? (Recommended)")
-                .initial_value(true)
-                .interact()?;
-
-        let (su_password, password) = if setup_database {
-            (pwd_input("admin")?, pwd_input("regular")?)
-        } else {
-            (String::new(), String::new())
-        };
-
-        config.setup_api_tokens = Some(if password != "password" || su_password != "password" {
-            confirm("Do you want to setup default API tokens for the admin and regular users? Will be created with `lip_{username}` format")
-            .interact()?
-        } else {
-            true
-        });
-
-        config.setup_database = Some(setup_database);
-        config.su_password = Some(su_password);
-        config.password = Some(password);
-
-        if Gitpod::is_host()
-        && confirm("By default, only this browser session can access your Gitpod development site.\nWould you like it to be accessible to other clients?")
-        .initial_value(false)
-        .interact()?
-        {
-            gitpod_public()?;
-        }
+    let setup_database = confirm(if first_setup {
+        "Do you want to seed the database with test users, games, etc? (Recommended)"
     } else {
-        setup_database = false;
+        "Do you want to re-seed the database with test users, games, etc?"
+    })
+    .initial_value(true)
+    .interact()?;
+
+    let (su_password, password) = if setup_database {
+        (pwd_input("admin")?, pwd_input("regular")?)
+    } else {
+        (String::new(), String::new())
+    };
+
+    config.setup_api_tokens = Some(if password != "password" || su_password != "password" {
+        confirm("Do you want to setup default API tokens for the admin and regular users? Will be created with `lip_{username}` format")
+        .interact()?
+    } else {
+        true
+    });
+
+    config.setup_database = Some(setup_database);
+    config.su_password = Some(su_password);
+    config.password = Some(password);
+
+    if Gitpod::is_host()
+    && confirm("By default, only this browser session can access your Gitpod development site.\nWould you like it to be accessible to other clients?")
+    .initial_value(false)
+    .interact()?
+    {
+        gitpod_public()?;
     }
 
     let new_profiles: Vec<String> = services

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -258,7 +258,7 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
         } else {
             true
         });
-        
+
         config.setup_database = Some(setup_database);
 
         if Gitpod::is_host()
@@ -271,7 +271,7 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
     } else {
         setup_database = false;
     }
-    
+
     let new_profiles: Vec<String> = services
         .iter()
         .filter_map(|service| service.compose_profile.as_ref())

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -225,13 +225,13 @@ fn pwd_input(user_type: &str) -> std::io::Result<String> {
     .interact()
 }
 
+#[allow(clippy::too_many_lines)]
 fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
     intro(BANNER)?;
 
     if !first_setup {
-        note(
-            "Already running services will not be affected by this setup.",
-            "Only the new services you select will be added."
+        info(
+            "NOTE: This will not affect the existing services.\nOnly the new ones among the selected services will be added."
         )?;
     }
     let services = prompt_for_optional_services()?;

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -236,7 +236,7 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
     }
     let services = prompt_for_optional_services()?;
 
-    let setup_database: bool; 
+    let setup_database: bool;
     if first_setup {
         setup_database =
             confirm("Do you want to seed the database with test users, games, etc? (Recommended)")
@@ -248,7 +248,7 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
         } else {
             (String::new(), String::new())
         };
-        
+
         config.su_password = Some(su_password.clone());
         config.password = Some(password.clone());
 
@@ -266,8 +266,7 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
         {
             gitpod_public()?;
         }
-    }
-    else {
+    } else {
         setup_database = false;
     }
 
@@ -283,7 +282,7 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
     if first_setup {
         config.setup_database = Some(setup_database);
     }
-    
+
     config.setup_bbppairings = Some(
         services
             .iter()

--- a/command/src/main.rs
+++ b/command/src/main.rs
@@ -249,9 +249,6 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
             (String::new(), String::new())
         };
 
-        config.su_password = Some(su_password.clone());
-        config.password = Some(password.clone());
-
         config.setup_api_tokens = Some(if password != "password" || su_password != "password" {
             confirm("Do you want to setup default API tokens for the admin and regular users? Will be created with `lip_{username}` format")
             .interact()?
@@ -260,6 +257,8 @@ fn setup(mut config: Config, first_setup: bool) -> std::io::Result<()> {
         });
 
         config.setup_database = Some(setup_database);
+        config.su_password = Some(su_password);
+        config.password = Some(password);
 
         if Gitpod::is_host()
         && confirm("By default, only this browser session can access your Gitpod development site.\nWould you like it to be accessible to other clients?")

--- a/lila-docker
+++ b/lila-docker
@@ -14,6 +14,13 @@ run_setup() {
     rust_cmd welcome
 }
 
+add_services() {
+    rust_cmd add_services
+    
+    docker compose build
+    docker compose up -d
+}
+
 run_start() {
     if [ -z "$(docker compose ps -a --services | xargs)" ]; then
         run_setup
@@ -156,7 +163,10 @@ show_help() {
     echo "  lila restart  Restart the lila container to apply changes to the codebase"
     echo "  gitpod public Make http port 8080 public on the Gitpod instance"
     echo "  ui            Compile the frontend code. Runs in watch mode to automatically recompile on changes"
+    echo "  add-services  Add new services to the existing setup"
 }
+
+cd "$(dirname "$0")"
 
 case "$@" in
     --help|-h)
@@ -204,6 +214,9 @@ case "$@" in
         ;;
     "flutter")
         rust_cmd flutter
+        ;;
+    "add-services")
+        add_services
         ;;
     *)
         show_help

--- a/lila-docker
+++ b/lila-docker
@@ -19,6 +19,8 @@ add_services() {
     
     docker compose build
     docker compose up -d
+    setup_bbppairings
+    setup_database
 }
 
 run_start() {

--- a/lila-docker
+++ b/lila-docker
@@ -16,7 +16,7 @@ run_setup() {
 
 add_services() {
     rust_cmd add_services
-    
+
     docker compose build
     docker compose up -d
     setup_bbppairings


### PR DESCRIPTION
Closes #47 
New services can now be added without `./lila-docker down`.
Do `./lila-docker add-services` to add new services, then select the new services you want to add.
Only the new ones among the selected services will be added.

Try on gitpod: https://gitpod.io/new/#https://github.com/Carbrex/lila-docker/tree/add-services-after-setup