### PR TITLE
better shebang

### DIFF
--- a/lila-docker
+++ b/lila-docker
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash 
+
+set -e
 
 run_setup() {
     write_user_id_to_env


### PR DESCRIPTION
This shebang is more portable than assuming bash is always available at /bin (NixOS for example)