### PR TITLE
Fix lila-docker when CARGO_TARGET_DIR is set

### DIFF
--- a/lila-docker
+++ b/lila-docker
@@ -87,8 +87,12 @@ run_mobile() {
 rust_cmd() {
     if command -v rustup &> /dev/null; then
         # if the host has Rust installed, use it directly
+
+        # if `CARGO_TARGET_DIR` is set, use `CARGO_TARGET_DIR/release/command`, else use `command/target/release/command`
+        COMMAND_EXE="${CARGO_TARGET_DIR:-command/target}/release/command"
+
         cargo build --release --manifest-path command/Cargo.toml
-        ./command/target/release/command "$@"
+        eval "$COMMAND_EXE $@"
     elif [ "$(uname)" = "Darwin" ]; then
         docker run --rm -v "$PWD/command:/command" -w /command messense/cargo-zigbuild:0.18.1 \
             cargo zigbuild --release --target universal2-apple-darwin


### PR DESCRIPTION
`CARGO_TARGET_DIR` is used by users with many rust crates to save on compile time and rust target/ dir size, because it allow for a central shared cargo target directory, sharing builds of common dependencies across projects. 
