### PR TITLE
Add GitHub Actions workflow for publishing Picfit image

### DIFF
--- a/.github/workflows/picfit-image.yml
+++ b/.github/workflows/picfit-image.yml
@@ -1,0 +1,55 @@
+name: Publish Picfit image
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '.github/workflows/picfit-image.yml'
+      - 'docker/picfit-image.Dockerfile'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout picfit
+        uses: actions/checkout@v4
+        with:
+          repository: 'thoas/picfit'
+          path: 'picfit'
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/picfit
+          tags: v1
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: docker/picfit-image.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docker/picfit-image.Dockerfile
+++ b/docker/picfit-image.Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM golang:1.22.1-alpine3.19 AS build
+
+RUN apk --no-cache add make
+
+COPY /picfit /picfit
+WORKDIR /picfit
+
+RUN make -C /picfit build
+
+# Runtime stage
+FROM alpine:3.19
+
+COPY --from=build /picfit/bin/picfit /picfit
+
+ENTRYPOINT ["/picfit"]


### PR DESCRIPTION
It has a hardcoded version number. I think it can be changed to something dynamic but I tried `tags: ${{ env.PICFIT_VERSION }}` but didn't work.
Also, we can change the picfit.Dockerfile to contain this image later.