### PR TITLE
Fix warning stripping debug info

### DIFF
--- a/command/Cargo.toml
+++ b/command/Cargo.toml
@@ -3,6 +3,9 @@ name = "command"
 version = "0.1.0"
 edition = "2021"
 
+[profile.release]
+strip = "none"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
when running this command:

```bash
docker run --rm -v "$PWD/command:/command" -w /command messense/cargo-zigbuild:0.19.1 cargo zigbuild --release --target universal2-apple-darwin
```

```
warning: stripping debug info with `strip` failed: exit status: 1
  |
  = note: strip: /command/target/aarch64-apple-darwin/release/deps/command-6779d3e9a71fe590: file format not recognized

warning: 1 warning emitted

    Finished `release` profile [optimized] target(s) in 5.83s
./lila-docker: line 172: 52486 Killed: 9               ./command/target/universal2-apple-darwin/release/command "$@"
```