### PR TITLE
Add script for when run using powershell

### DIFF
--- a/lila-docker.ps1
+++ b/lila-docker.ps1
@@ -1,4 +1,5 @@
-echo "   |\_    _ _      _
+echo "
+   |\_    _ _      _
    /o \  | (_) ___| |__   ___  ___ ___   ___  _ __ __ _
  (_. ||  | | |/ __| '_ \ / _ \/ __/ __| / _ \| '__/ _` |
    /__\  | | | (__| | | |  __/\__ \__ \| (_) | | | (_| |
@@ -7,3 +8,4 @@ echo "   |\_    _ _      _
 
 echo "If you are trying to run lila-docker on Windows, you need to install and use Windows with WSL"
 echo "See the instructions at https://aka.ms/wslstore"
+echo ""

--- a/lila-docker.ps1
+++ b/lila-docker.ps1
@@ -1,2 +1,9 @@
-echo "If you're trying to run lila-docker on Windows, you need to install and use Windows with WSL"
+echo "   |\_    _ _      _
+   /o \  | (_) ___| |__   ___  ___ ___   ___  _ __ __ _
+ (_. ||  | | |/ __| '_ \ / _ \/ __/ __| / _ \| '__/ _` |
+   /__\  | | | (__| | | |  __/\__ \__ \| (_) | | | (_| |
+  )___(  |_|_|\___|_| |_|\___||___/___(_)___/|_|  \__, |
+                                                   |___/"
+
+echo "If you are trying to run lila-docker on Windows, you need to install and use Windows with WSL"
 echo "See the instructions at https://aka.ms/wslstore"

--- a/lila-docker.ps1
+++ b/lila-docker.ps1
@@ -1,0 +1,2 @@
+echo "If you're trying to run lila-docker on Windows, you need to install and use Windows with WSL"
+echo "See the instructions at https://aka.ms/wslstore"


### PR DESCRIPTION
If `./lila-docker` was run from powershell before it would not show an error.
If there's a `lila-docker.ps1` file, it will execute that and we can at least give a hint of what to do.