### PR TITLE
Add SHELL to avoid JSONArgsRecommended warning

### DIFF
--- a/docker/ci.Dockerfile
+++ b/docker/ci.Dockerfile
@@ -63,6 +63,7 @@ ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ENV LANG=C.utf8
 
 WORKDIR /lila
+SHELL ["/bin/bash", "-c"]
 CMD mongod --fork --logpath /var/log/mongodb/mongod.log --dbpath /seeded \
     && redis-server --daemonize yes \
     && wait-for localhost:27017 --timeout=15 \


### PR DESCRIPTION
After adding `SHELL` field as mentioned in the doc, I no longer get the warning.  

Is this good enough, or is there a desire to specifically change the `CMD` field?


Resolves: #117