### PR TITLE
Disable pnpm install prompts during ui build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -233,6 +233,8 @@ services:
       dockerfile: ui.Dockerfile
     restart: unless-stopped
     user: ${USER_ID}:${GROUP_ID}
+    environment:
+      - CI=1 # to disable pnpm install prompts
     networks:
       - lila-network
     volumes:


### PR DESCRIPTION
If you switch from running `./ui/build` on the host vs the container, you may get a prompt like this before installation can continue:

![image](https://github.com/user-attachments/assets/8912a472-b945-4b8c-b16a-6d023c1e682c)
