### PR TITLE
Set env vars for lila-search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,6 +287,10 @@ services:
       - ELASTIC_URI=http://elasticsearch:9200
       - HTTP_API_LOGGER=true
       - HTTP_ENABLE_DOCS=true
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=none
+      - OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0
+      - OTEL_EXPORTER_PROMETHEUS_PORT=9465
     ports:
       - 9673:9673
     networks:
@@ -319,6 +323,10 @@ services:
       - INGESTOR_FORUM_TIME_WINDOWS=1
       - INGESTOR_STUDY_INTERVAL=10
       - INGESTOR_STUDY_START_AT=1344789787
+      - OTEL_METRICS_EXPORTER=none
+      - OTEL_TRACES_EXPORTER=none
+      - OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0
+      - OTEL_EXPORTER_PROMETHEUS_PORT=9465
     networks:
       - lila-network
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,8 +289,6 @@ services:
       - HTTP_ENABLE_DOCS=true
       - OTEL_METRICS_EXPORTER=none
       - OTEL_TRACES_EXPORTER=none
-      - OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0
-      - OTEL_EXPORTER_PROMETHEUS_PORT=9465
     ports:
       - 9673:9673
     networks:
@@ -325,8 +323,6 @@ services:
       - INGESTOR_STUDY_START_AT=1344789787
       - OTEL_METRICS_EXPORTER=none
       - OTEL_TRACES_EXPORTER=none
-      - OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0
-      - OTEL_EXPORTER_PROMETHEUS_PORT=9465
     networks:
       - lila-network
     volumes:


### PR DESCRIPTION
Fixes

```
[error] The configurer for the [otlp] exporter is not registered.
[error] Add the `otel4s-sdk-exporter` dependency to the build file:
[error] libraryDependencies += "org.typelevel" %%% "otel4s-sdk-exporter" % "x.x.x"
[error] and register the configurer via OpenTelemetrySdk:
[error] import org.typelevel.otel4s.sdk.OpenTelemetrySdk
[error] import org.typelevel.otel4s.sdk.exporter.otlp.autoconfigure.OtlpExportersAutoConfigure
[error] OpenTelemetrySdk.autoConfigured[IO](
[error]   _.addExportersConfigurer(OtlpExportersAutoConfigure[IO])
[error] )
[error] or via SdkMetrics:
[error] import org.typelevel.otel4s.sdk.metrics.SdkMetrics
[error] import org.typelevel.otel4s.sdk.exporter.otlp.metrics.autoconfigure.OtlpMetricExporterAutoConfigure
[error] SdkMetrics.autoConfigured[IO](
[error]   _.addExporterConfigurer(OtlpMetricExporterAutoConfigure[IO])
[error] )
[error] org.typelevel.otel4s.sdk.autoconfigure.AutoConfigureError: Cannot autoconfigure [MetricExporters].
[error] Cause: Unrecognized value for [otel.metrics.exporter]: otlp. Supported options [none, console].
```