### PR TITLE
Fix lila-engine build + add memory requirements to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Also, see [gitpod-prebuilds.md](gitpod-prebuilds.md) for more information on how
 
     Starting new services may take 5-10 minutes. Some services will start before others and you may see errors in the logs until everything comes online.
 
+    Lila requires about 12GB of RAM to build. Make sure there is enough RAM
+    available, especially when using Docker Desktop, which allocates 50% of
+    the available RAM by default.
+
     Lila will be the last service to complete, at which point you can visit http://localhost:8080/ to see the site.
 
 ### Stopping

--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ Also, see [gitpod-prebuilds.md](gitpod-prebuilds.md) for more information on how
 
     Starting new services may take 5-10 minutes. Some services will start before others and you may see errors in the logs until everything comes online.
 
-    Lila requires about 12GB of RAM to build. Make sure there is enough RAM
-    available, especially when using Docker Desktop, which allocates 50% of
-    the available RAM by default.
+    Lila requires about 12GB of RAM to build. Make sure there is enough RAM available, especially when using Docker Desktop, which allocates 50% of the available RAM by default.
 
     Lila will be the last service to complete, at which point you can visit http://localhost:8080/ to see the site.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -331,7 +331,7 @@ services:
       - search
 
   lila_gif:
-    image: rust:1.84.0-slim-bookworm
+    image: rust:1.84.0-bookworm
     working_dir: /lila-gif
     entrypoint: cargo run -- --bind 0.0.0.0:6175
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,9 @@ services:
       - pgn-viewer
 
   lila_engine:
-    image: rust:1.84.0-slim-bookworm
+    build:
+      context: docker
+      dockerfile: rustmake.Dockerfile
     working_dir: /lila-engine
     entrypoint: cargo run -- --bind 0.0.0.0:9666 --mongodb mongodb://mongodb
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,9 +146,7 @@ services:
       - pgn-viewer
 
   lila_engine:
-    build:
-      context: docker
-      dockerfile: rustmake.Dockerfile
+    image: rust:1.84.0-bookworm
     working_dir: /lila-engine
     entrypoint: cargo run -- --bind 0.0.0.0:9666 --mongodb mongodb://mongodb
     restart: unless-stopped

--- a/docker/rustmake.Dockerfile
+++ b/docker/rustmake.Dockerfile
@@ -1,5 +1,0 @@
-FROM rust:1.84.0-slim-bookworm
-
-RUN apt update \
-    && apt install -y make \
-    && apt clean

--- a/docker/rustmake.Dockerfile
+++ b/docker/rustmake.Dockerfile
@@ -1,0 +1,5 @@
+FROM rust:1.84.0-slim-bookworm
+
+RUN apt update \
+    && apt install -y make \
+    && apt clean


### PR DESCRIPTION
Here's a fix for two issues I had when first using lila-docker.

Regarding the first issue, on Linux aarch64 (via Docker Desktop for Mac), the dependency tikv-jemalloc-sys of lila-engine isn't precompiled, so the toolchain tries to build it, which doesn't work because the docker image doesn't include make.
