### PR TITLE
Update nodejs version so ui builds

### DIFF
--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.15.0-bookworm-slim
+FROM node:24.4.1-bookworm-slim
 
 USER root
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0


### PR DESCRIPTION
Currently ui.Dockerfile nodejs version is behind:
<img width="444" height="143" alt="250717_12h30m04s_screenshot" src="https://github.com/user-attachments/assets/854339b4-7b0e-48b4-b298-a8618734c814" />
Updated:
<img width="816" height="304" alt="250717_12h33m50s_screenshot" src="https://github.com/user-attachments/assets/76d1a973-38d5-488b-ba68-3bb8aafa9568" />
