### PR TITLE
Add option to use prebuilt lila-ws image

### DIFF
--- a/compose-lila-ws-build.yml
+++ b/compose-lila-ws-build.yml
@@ -1,0 +1,20 @@
+services:
+  lila_ws:
+    build:
+      context: docker
+      args:
+        USER_ID: ${USER_ID}
+        GROUP_ID: ${GROUP_ID}
+      dockerfile: sbt.Dockerfile
+    user: ${USER_ID}:${GROUP_ID}
+    working_dir: /lila-ws
+    entrypoint: sbt run -Dconfig.file=/lila-ws.conf
+    restart: unless-stopped
+    environment:
+      - LILA_URL=${LILA_URL:-http://localhost:8080}
+      - ENABLE_MONITORING=${ENABLE_MONITORING:-false}
+    volumes:
+      - ./repos/lila-ws:/lila-ws
+      - ./conf/lila-ws.conf:/lila-ws.conf
+    profiles:
+      - lila-ws-build

--- a/compose-lila-ws-image.yml
+++ b/compose-lila-ws-image.yml
@@ -1,0 +1,13 @@
+services:
+  lila_ws:
+    image: ghcr.io/lichess-org/lila-ws:latest
+    restart: unless-stopped
+    environment:
+      - CONFIG_FORCE_csrf.origin=${LILA_URL:-http://localhost:8080}
+      - CONFIG_FORCE_kamon.enabled=${ENABLE_MONITORING:-false}
+      - CONFIG_FORCE_influxdb.hostname=influxdb
+      - CONFIG_FORCE_influxdb.authentication.token=secret
+      - CONFIG_FORCE_mongo_uri=mongodb://mongo:27017/lichess?appName=lila-ws
+      - CONFIG_FORCE_redis.uri=redis://redis
+    profiles:
+      - base

--- a/compose.yml
+++ b/compose.yml
@@ -58,39 +58,6 @@ services:
     profiles:
       - base
 
-  # lila_ws:
-  #   build:
-  #     context: docker
-  #     args:
-  #       USER_ID: ${USER_ID}
-  #       GROUP_ID: ${GROUP_ID}
-  #     dockerfile: sbt.Dockerfile
-  #   user: ${USER_ID}:${GROUP_ID}
-  #   working_dir: /lila-ws
-  #   entrypoint: sbt run -Dconfig.file=/lila-ws.conf
-  #   restart: unless-stopped
-  #   environment:
-  #     - LILA_URL=${LILA_URL:-http://localhost:8080}
-  #     - ENABLE_MONITORING=${ENABLE_MONITORING:-false}
-  #   volumes:
-  #     - ./repos/lila-ws:/lila-ws
-  #     - ./conf/lila-ws.conf:/lila-ws.conf
-  #   profiles:
-  #     - lila-ws-build
-  
-  # lila_ws:
-  #   image: ghcr.io/lichess-org/lila-ws:latest
-  #   restart: unless-stopped
-  #   environment:
-  #     - CONFIG_FORCE_csrf.origin=${LILA_URL:-http://localhost:8080}
-  #     - CONFIG_FORCE_kamon.enabled=${ENABLE_MONITORING:-false}
-  #     - CONFIG_FORCE_influxdb.hostname=influxdb
-  #     - CONFIG_FORCE_influxdb.authentication.token=secret
-  #     - CONFIG_FORCE_mongo_uri=mongodb://mongo:27017/lichess?appName=lila-ws
-  #     - CONFIG_FORCE_redis.uri=redis://redis
-  #   profiles:
-  #     - base
-
   nginx:
     image: nginx:1.27.5-alpine3.21-slim
     restart: unless-stopped

--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,6 @@
+include:
+  - compose-lila-ws-${LILA_WS_CONTAINER:-image}.yml
+
 services:
   mongodb:
     image: mongo:7.0.20-jammy
@@ -55,25 +58,38 @@ services:
     profiles:
       - base
 
-  lila_ws:
-    build:
-      context: docker
-      args:
-        USER_ID: ${USER_ID}
-        GROUP_ID: ${GROUP_ID}
-      dockerfile: sbt.Dockerfile
-    user: ${USER_ID}:${GROUP_ID}
-    working_dir: /lila-ws
-    entrypoint: sbt run -Dconfig.file=/lila-ws.conf
-    restart: unless-stopped
-    environment:
-      - LILA_URL=${LILA_URL:-http://localhost:8080}
-      - ENABLE_MONITORING=${ENABLE_MONITORING:-false}
-    volumes:
-      - ./repos/lila-ws:/lila-ws
-      - ./conf/lila-ws.conf:/lila-ws.conf
-    profiles:
-      - base
+  # lila_ws:
+  #   build:
+  #     context: docker
+  #     args:
+  #       USER_ID: ${USER_ID}
+  #       GROUP_ID: ${GROUP_ID}
+  #     dockerfile: sbt.Dockerfile
+  #   user: ${USER_ID}:${GROUP_ID}
+  #   working_dir: /lila-ws
+  #   entrypoint: sbt run -Dconfig.file=/lila-ws.conf
+  #   restart: unless-stopped
+  #   environment:
+  #     - LILA_URL=${LILA_URL:-http://localhost:8080}
+  #     - ENABLE_MONITORING=${ENABLE_MONITORING:-false}
+  #   volumes:
+  #     - ./repos/lila-ws:/lila-ws
+  #     - ./conf/lila-ws.conf:/lila-ws.conf
+  #   profiles:
+  #     - lila-ws-build
+  
+  # lila_ws:
+  #   image: ghcr.io/lichess-org/lila-ws:latest
+  #   restart: unless-stopped
+  #   environment:
+  #     - CONFIG_FORCE_csrf.origin=${LILA_URL:-http://localhost:8080}
+  #     - CONFIG_FORCE_kamon.enabled=${ENABLE_MONITORING:-false}
+  #     - CONFIG_FORCE_influxdb.hostname=influxdb
+  #     - CONFIG_FORCE_influxdb.authentication.token=secret
+  #     - CONFIG_FORCE_mongo_uri=mongodb://mongo:27017/lichess?appName=lila-ws
+  #     - CONFIG_FORCE_redis.uri=redis://redis
+  #   profiles:
+  #     - base
 
   nginx:
     image: nginx:1.27.5-alpine3.21-slim
@@ -84,9 +100,6 @@ services:
       - ./conf/nginx.conf:/etc/nginx/conf.d/default.conf
       - ./repos/lila/public:/lila/public
       - ./nginx:/nginx
-    depends_on:
-      - lila
-      - lila_ws
     profiles:
       - base
 


### PR DESCRIPTION
lila-ws publishes an image to ghcr ([workflow here](https://github.com/lichess-org/lila-ws/blob/master/.github/workflows/docker.yml))

This adds it as an option during setup. By default, the ghcr image will be used. Otherwise it will build it (like the current behavior does).

This should make setup faster and less resource intensive.