### PR TITLE
Fix unreachable tip in run_ui_build

### DIFF
--- a/lila-docker
+++ b/lila-docker
@@ -73,11 +73,12 @@ build_all_profiles() {
 }
 
 run_ui_build() {
-    ARGS=(--debug $@)
+    local no_args=$(( $# == 0 ))
+    ARGS=(--debug "$@")
     echo "Running: ./ui/build ${ARGS[@]}"
     docker compose run --rm ui /lila/ui/build "${ARGS[@]}"
 
-    if [[ ${#ARGS[@]} -eq 0 ]]; then
+    if (( no_args )); then
         echo "💡 Tip: Run './lila-docker ui --watch' to watch typescript and scss sources so any changes are visible on browser reloads"
     fi
 }


### PR DESCRIPTION
Hi, 

Tiny pr for something that I noticed. Hope you would accept this contribution, happy to adjust if you'd prefer a different approach!

`ARGS=(--debug $@)` unconditionally prepends `--debug`, so `${#ARGS[@]} -eq 0` on line 80 is never true and the tip never prints. Capture `$# == 0` before mutating `ARGS`, and quote `"$@"` while here to match the call site on line 282.