### PR TITLE
Bumped node version for UI repo

### DIFF
--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,5 +1,5 @@
 # match node version from https://github.com/lichess-org/lila/blob/master/.node-version
-FROM node:24.14-trixie-slim
+FROM node:24.15.0-trixie-slim
 
 USER root
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0


### PR DESCRIPTION
Good morning 👋 

First of all, thank you for the amazing chess platform.

I've noticed that, while trying to set up the lila-docker repo in my local server, I ran into an error while building the `ui` repo.

This PR is just bumping the node version to the required version in the `ui` Docker container so the repo can build properly.