### PR TITLE
Fix lila-ws under sbt 2

### DIFF
--- a/compose-lila-ws-build.yml
+++ b/compose-lila-ws-build.yml
@@ -8,9 +8,13 @@ services:
       dockerfile: sbt.Dockerfile
     user: ${USER_ID:-}:${GROUP_ID:-}
     working_dir: /lila-ws
-    entrypoint: sbt run -Dconfig.file=/lila-ws.conf
+    # sbt 2.x defaults `run / fork` to true, so `sbt run -Dconfig.file=...` passes the
+    # option as an application argument instead of a JVM option and it gets ignored.
+    # JAVA_TOOL_OPTIONS is read by every JVM, including the forked one.
+    entrypoint: sbt run
     restart: unless-stopped
     environment:
+      - JAVA_TOOL_OPTIONS=-Dconfig.file=/lila-ws.conf
       - LILA_URL=${LILA_URL:-http://localhost:8080}
       - ENABLE_MONITORING=${ENABLE_MONITORING:-false}
     volumes:

--- a/compose-lila-ws-build.yml
+++ b/compose-lila-ws-build.yml
@@ -8,9 +8,6 @@ services:
       dockerfile: sbt.Dockerfile
     user: ${USER_ID:-}:${GROUP_ID:-}
     working_dir: /lila-ws
-    # sbt 2.x defaults `run / fork` to true, so `sbt run -Dconfig.file=...` passes the
-    # option as an application argument instead of a JVM option and it gets ignored.
-    # JAVA_TOOL_OPTIONS is read by every JVM, including the forked one.
     entrypoint: sbt run
     restart: unless-stopped
     environment:

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -29,7 +29,10 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:lila-ws]
-command=/lila-ws/target/universal/stage/bin/lila-ws -Dcsrf.origin=%(ENV_LILA_URL)s
+# sbt 1 stages to target/universal/stage; sbt 2 (which lila-ws is on) stages to
+# target/out/jvm/<scala>/<project>/universal/stage. Accept either, so this keeps
+# working whichever side migrates next.
+command=bash -c 'exec $(ls -d /lila-ws/target/universal/stage/bin/lila-ws /lila-ws/target/out/jvm/*/lila-ws/universal/stage/bin/lila-ws 2>/dev/null | head -1) -Dcsrf.origin=%(ENV_LILA_URL)s'
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -29,9 +29,6 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 
 [program:lila-ws]
-# sbt 1 stages to target/universal/stage; sbt 2 (which lila-ws is on) stages to
-# target/out/jvm/<scala>/<project>/universal/stage. Accept either, so this keeps
-# working whichever side migrates next.
 command=bash -c 'exec $(ls -d /lila-ws/target/universal/stage/bin/lila-ws /lila-ws/target/out/jvm/*/lila-ws/universal/stage/bin/lila-ws 2>/dev/null | head -1) -Dcsrf.origin=%(ENV_LILA_URL)s'
 autostart=true
 autorestart=true


### PR DESCRIPTION
lila-ws is on sbt 2.0.4 now, and two spots in this repo still assume sbt 1 behaviour. Both break the websocket, in the two different setups.

## 1. Advanced setup: the config file is ignored

sbt 2 defaults `run / fork` to `true`. With a forked run, `sbt run -Dconfig.file=/lila-ws.conf` no longer sets a system property on the JVM that runs the app; sbt passes it along as an *application argument*. The process ends up as:

```
java -Xms32m -Xmx256m -classpath ... lila.ws.LilaWs -Dconfig.file=/lila-ws.conf
```

Note where the option sits: after the main class. `ConfigFactory.load` never sees it, so `/lila-ws.conf` is not read, `redis.uri` stays at its default and lila-ws dies during boot:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
Caused by: io.lettuce.core.RedisConnectionException: Unable to connect to 127.0.0.1/<unresolved>:6379
```

`JAVA_TOOL_OPTIONS` is read by every JVM, including forked ones, so it reaches the app whichever way `fork` is set.

I first tried `sbt "set Compile / run / javaOptions += ..." run`, but sbt joins its argv into one command line and fails to parse that as two commands.

## 2. Quick/mono setup: supervisord cannot find the binary

sbt 2 stages to `target/out/jvm/<scala>/<project>/universal/stage` instead of `target/universal/stage`, so the path in `conf/supervisord.conf` no longer exists:

```
spawnerr: can't find command '/lila-ws/target/universal/stage/bin/lila-ws'
gave up: lila-ws entered FATAL state, too many start retries too quickly
```

Nothing then listens on 9664, and `conf/mono.Caddyfile`'s `handle_errors 502` serves its static page for every socket upgrade. The browser gets 502 where it expects `101 Switching Protocols`, so it reconnects forever and the site shows a permanent "Reconnecting" badge. Everything else looks healthy, which makes this easy to miss: the container stays up and every page still returns 200.

This affects the published `ghcr.io/lichess-org/lila-docker:main` image, not just local builds.

The patch resolves either layout rather than just swapping to the new one, so it keeps working when lila migrates to sbt 2 too. lila is still on sbt 1 and is unaffected today.

## Verified

Change 1 against a full advanced setup, change 2 against a mono image built from this branch and deployed behind a reverse proxy. In both, lila-ws logs `Listening to 9664`, `LILA BOOT` and `LILA VERSIONING READY`, and `GET /lobby/socket/v5?sri=...` with upgrade headers answers `101 Switching Protocols` with a valid `Sec-WebSocket-Accept` where it previously answered `502`.

## Unrelated, happy to send separately

While testing I also hit both fishnet clients failing to acquire work: `fishnet_play` has no `KEY`, so it sends a bare `Authorization: Bearer` header that lila-fishnet cannot parse and answers with 400, after which the client exits. `fishnet_analysis` gets a 404 because lila authenticates analysis clients against the `fishnet_client` collection and nothing in the setup creates a matching document. The second one needs a seeding change as well as a compose change, so I left both out of this PR to keep it focused.
