### PR TITLE
configure auth mask for lila-fishnet

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -176,6 +176,7 @@ services:
     entrypoint: sbt app/run
     environment:
       - REDIS_HOST=redis
+      - HTTP_AUTH_MASK=255.255.0.0 # allow token free requests from /16
       # - HTTP_API_LOGGER=true
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
I believe service ips on a docker bridge network are assigned from /16 but this has not been tested.

This should make play against computer work again (in tandem with https://github.com/lichess-org/lila-fishnet/pull/633)