### PR TITLE
bump rust images to 1.95 required by `lila-engine` and `lila-gif`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -152,7 +152,7 @@ services:
     profiles:
       - pgn-viewer
   lila_engine:
-    image: rust:1.89.0-trixie
+    image: rust:1.95.0-trixie
     working_dir: /lila-engine
     entrypoint: cargo run -- --bind 0.0.0.0:9666 --mongodb mongodb://mongodb
     restart: unless-stopped
@@ -230,7 +230,7 @@ services:
     profiles:
       - utils
   lila_gif:
-    image: rust:1.89.0-trixie
+    image: rust:1.95.0-trixie
     working_dir: /lila-gif
     entrypoint: cargo run -- --bind 0.0.0.0:6175
     restart: unless-stopped
@@ -242,7 +242,7 @@ services:
     profiles:
       - gifs
   lila_push:
-    image: rust:1.89.0-trixie
+    image: rust:1.95.0-trixie
     working_dir: /lila-push
     entrypoint: cargo run --release -- --vapid private.pem --vapid-subject mailto:contact@lichess.org
       --bind 0.0.0.0:9054


### PR DESCRIPTION
# Why

`lila-engine` and `lila-gif` fails to compile and run.

<img width="984" height="153" alt="Screenshot 2026-08-04 at 12 19 21" src="https://github.com/user-attachments/assets/d294ae3a-0f65-43db-9044-9d1a6dbd610a" />

Also refs:
* https://github.com/lichess-org/lila-engine/pull/64

# How

Bump all used rust images to 1.95 to satisfy the minimum requirements.

# Test plan

Apply changes locally, run `docker compose up -d --pull always --force-recreate lila_engine`.

<img width="984" height="153" alt="Screenshot 2026-08-04 at 12 34 06" src="https://github.com/user-attachments/assets/fbae00ec-d67e-432d-90b8-6a8575114415" />
