### PR TITLE
fix `api_docs` not starting up

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -102,7 +102,7 @@ services:
     entrypoint:
       - /bin/sh
       - -c
-      - npm install && npm run serve -- --host=0.0.0.0
+      - pnpm install && pnpm dev --host 0.0.0.0
     restart: unless-stopped
     user: ${USER_ID:-}:${GROUP_ID:-}
     ports:


### PR DESCRIPTION
# How

Fix `api_docs` app not starting up due to calling non-existing `serve` script.

```
Run `npm audit` for details.
npm error Missing script: "serve"
npm error
npm error To see a list of scripts, run:
npm error   npm run
npm error A complete log of this run can be found in: /.npm/_logs/2026-08-03T15_54_24_733Z-debug-0.log
```

Migrate to pnpm since this is what project uses, run in hosted dev mode.

# Preview

<img width="734" height="468" alt="Screenshot 2026-08-05 at 11 42 12" src="https://github.com/user-attachments/assets/ee29887c-398a-445f-9e85-19249f30b7a1" />

<img width="756" height="370" alt="Screenshot 2026-08-05 at 11 40 51" src="https://github.com/user-attachments/assets/36de074d-d407-4cab-8597-731bbed40069" />
