### PR TITLE
Update scalachess stuff in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,25 +157,39 @@ Once the build has been imported, you should have code completion, go to definit
 
 If you're making changes to the Scalachess library, you can have lila use it instead of the published Maven version:
 
-1. Update the `build.sbt` file in the scalachess repo:
+1. Make sure you already have lila-docker up and running, with lila currently using the published Maven version of scalachess.
+
+2. Then, update the `build.sbt` file in the scalachess repo:
 
     ```diff
     -  version := "17.16.1"
+    -  organization := "com.github.lichess-org.scalachess"
     +  version := "my-test-1"  # give it a custom version
+    +  organization := "org.lichess"
     ```
 
-2. Update the `Dependencies.scala` file in the lila repo:
+3. Publish your local scalachess changes:
+
+    ```bash
+    docker compose exec -w /scalachess lila sbt publishLocal
+    ```
+
+4. Make any code changes you may require in lila to use your scalachess version.
+
+5. Update the `Dependencies.scala` file in lila:
 
     ```diff
        object chess:
     -    val version = "17.16.1"
+    -    val org = "com.github.lichess-org.scalachess"
+    -    // val org = "org.lichess" // for publishLocal
     +    val version = "my-test-1"
+    +    val org = "org.lichess" // for publishLocal
     ```
 
-3. Publish the local scalachess changes and restart lila:
+6. Restart lila:
 
     ```bash
-    docker compose exec -w /scalachess lila sbt publishLocal
     ./lila-docker lila restart
     ```
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you're making changes to the Scalachess library, you can have lila use it ins
 
     ```bash
     docker compose exec -w /scalachess lila sbt publishLocal
-    docker compose restart lila
+    ./lila-docker lila restart
     ```
 
 Other Scalachess commands:

--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ If you're making changes to the Scalachess library, you can have lila use it ins
 2. Update the `Dependencies.scala` file in the lila repo:
 
     ```diff
-    -  val chess = "org.lichess" %% "scalachess" % "15.6.7"
-    +  val chess = "org.lichess" %% "scalachess" % "my-test-1"
+       object chess:
+    -    val version = "17.16.1"
+    +    val version = "my-test-1"
     ```
 
 3. Publish the local scalachess changes and restart lila:

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ docker compose run --rm -w /lila ui pnpm run i18n-file-gen
 docker compose cp mongodb:/data/db ./database
 ```
 
-Then, in `compose.yml`,  under `services.mongodb.volumes`: 
+Then, in `compose.yml`, under `services.mongodb.volumes`:
 
 Add `- ./database:/data/db`
 
@@ -160,8 +160,8 @@ If you're making changes to the Scalachess library, you can have lila use it ins
 1. Update the `build.sbt` file in the scalachess repo:
 
     ```diff
-    -  ThisBuild / version           := "15.6.7"
-    +  ThisBuild / version           := "my-test-1"  # give it a custom version
+    -  version := "17.16.1"
+    +  version := "my-test-1"  # give it a custom version
     ```
 
 2. Update the `Dependencies.scala` file in the lila repo:


### PR DESCRIPTION
d553157 and 5c76678 keep the readme updated with changes that have occurred in lila and scalachess. I had trouble for a long time getting my scalachess changes to be built properly by lila-docker, so 6a41321 is an attempt to help others avoid the issues I had.